### PR TITLE
chore(github): add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -1,0 +1,30 @@
+---
+name: "\U0001F41B Bug Report"
+about: "If something isn't working as expected \U0001F914."
+title: ""
+labels: "bug"
+assignees: ""
+---
+
+## Bug Report
+
+**Current behavior**
+A clear and concise description of the behavior.
+
+**Environment**
+
+- `env_logger` version:
+- Rust version:
+- Compilation target triple:
+- OS:
+
+**Possible Solution**
+
+<!--- If you have suggestions on a fix for the bug -->
+
+**Additional context**
+Add any other context about the problem here. Or a screenshot if applicable
+
+<!-- Contributors are always welcome, feel free to put a cross here! ... Don't be shy :) -->
+
+- [ ] I would like to work on a fix!

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -1,0 +1,20 @@
+---
+name: "\U0001F680 Feature Request"
+about: "I have an idea!"
+title: ""
+labels: "enhancement"
+assignees: ""
+---
+
+## Feature Request
+
+**Is your feature request related to a problem?**
+A concise description of what the problem is.
+
+**Describe the solution you'd like**
+
+**Describe alternatives you've considered**.
+
+<!-- Contributors are always welcome, feel free to put a cross here! ... Don't be shy :) -->
+
+- [ ] I would like to work on this feature!


### PR DESCRIPTION
The templates are inspired by the ones I found some time ago on babel. I changed them a little bit to fit better :)