### PR TITLE
Disable regex "perf" feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 
 [dependencies]
 log = { version = "0.4.8", features = ["std"] }
-regex = { version = "1.0.3", optional = true, default-features=false, features=["std", "perf"] }
+regex = { version = "1.0.3", optional = true, default-features=false, features=["std"] }
 termcolor = { version = "1.0.2", optional = true }
 humantime = { version = "2.0.0", optional = true }
 atty = { version = "0.2.5", optional = true }


### PR DESCRIPTION
Users can still enable it if needed.

Normally "env_logger" is used as a dev dependency, but because
`-Z features=dev_dep` is not stabilized yet[1], "perf" feature leaks into
build dependencies and makes it impossible to disable "perf" feature,
except by disabling "env_logger".

[1] https://github.com/rust-lang/cargo/issues/7916