### PR TITLE
Take `self` by value in build()

### DIFF
--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -29,7 +29,7 @@
 //!
 //!         // Parse a directives string from an environment variable
 //!         if let Ok(ref filter) = std::env::var("MY_LOG_LEVEL") {
-//!            builder.parse(filter);
+//!            builder = builder.parse(filter);
 //!         }
 //!
 //!         MyLogger {
@@ -99,7 +99,7 @@ pub struct Filter {
 ///
 /// // Parse a logging filter from an environment variable.
 /// if let Ok(rust_log) = env::var("RUST_LOG") {
-///     builder.parse(&rust_log);
+///     builder = builder.parse(&rust_log);
 /// }
 ///
 /// let filter = builder.build();
@@ -128,11 +128,11 @@ impl Filter {
     /// use log::LevelFilter;
     /// use env_logger::filter::Builder;
     ///
-    /// let mut builder = Builder::new();
-    /// builder.filter(Some("module1"), LevelFilter::Info);
-    /// builder.filter(Some("module2"), LevelFilter::Error);
+    /// let filter = Builder::new()
+    ///     .filter(Some("module1"), LevelFilter::Info)
+    ///     .filter(Some("module2"), LevelFilter::Error)
+    ///     .build();
     ///
-    /// let filter = builder.build();
     /// assert_eq!(filter.filter(), LevelFilter::Info);
     /// ```
     pub fn filter(&self) -> LevelFilter {
@@ -182,19 +182,19 @@ impl Builder {
         let mut builder = Builder::new();
 
         if let Ok(s) = env::var(env) {
-            builder.parse(&s);
+            builder = builder.parse(&s);
         }
 
         builder
     }
 
     /// Adds a directive to the filter for a specific module.
-    pub fn filter_module(&mut self, module: &str, level: LevelFilter) -> &mut Self {
+    pub fn filter_module(self, module: &str, level: LevelFilter) -> Self {
         self.filter(Some(module), level)
     }
 
     /// Adds a directive to the filter for all modules.
-    pub fn filter_level(&mut self, level: LevelFilter) -> &mut Self {
+    pub fn filter_level(self, level: LevelFilter) -> Self {
         self.filter(None, level)
     }
 
@@ -202,7 +202,7 @@ impl Builder {
     ///
     /// The given module (if any) will log at most the specified level provided.
     /// If no module is provided then the filter will apply to all log messages.
-    pub fn filter(&mut self, module: Option<&str>, level: LevelFilter) -> &mut Self {
+    pub fn filter(mut self, module: Option<&str>, level: LevelFilter) -> Self {
         self.directives.push(Directive {
             name: module.map(|s| s.to_string()),
             level,
@@ -215,7 +215,7 @@ impl Builder {
     /// See the [Enabling Logging] section for more details.
     ///
     /// [Enabling Logging]: ../index.html#enabling-logging
-    pub fn parse(&mut self, filters: &str) -> &mut Self {
+    pub fn parse(mut self, filters: &str) -> Self {
         let (directives, filter) = parse_spec(filters);
 
         self.filter = filter;

--- a/src/fmt/writer/mod.rs
+++ b/src/fmt/writer/mod.rs
@@ -86,7 +86,7 @@ impl Builder {
     }
 
     /// Set the target to write to.
-    pub(crate) fn target(&mut self, target: Target) -> &mut Self {
+    pub(crate) fn target(mut self, target: Target) -> Self {
         self.target = target;
         self
     }
@@ -96,18 +96,18 @@ impl Builder {
     /// See the [Disabling colors] section for more details.
     ///
     /// [Disabling colors]: ../index.html#disabling-colors
-    pub(crate) fn parse_write_style(&mut self, write_style: &str) -> &mut Self {
+    pub(crate) fn parse_write_style(self, write_style: &str) -> Self {
         self.write_style(parse_write_style(write_style))
     }
 
     /// Whether or not to print style characters when writing.
-    pub(crate) fn write_style(&mut self, write_style: WriteStyle) -> &mut Self {
+    pub(crate) fn write_style(mut self, write_style: WriteStyle) -> Self {
         self.write_style = write_style;
         self
     }
 
     /// Whether or not to capture logs for `cargo test`.
-    pub(crate) fn is_test(&mut self, is_test: bool) -> &mut Self {
+    pub(crate) fn is_test(mut self, is_test: bool) -> Self {
         self.is_test = is_test;
         self
     }

--- a/src/fmt/writer/mod.rs
+++ b/src/fmt/writer/mod.rs
@@ -107,6 +107,7 @@ impl Builder {
     }
 
     /// Whether or not to capture logs for `cargo test`.
+    #[allow(clippy::wrong_self_convention)]
     pub(crate) fn is_test(mut self, is_test: bool) -> Self {
         self.is_test = is_test;
         self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -731,7 +731,7 @@ impl Builder {
     ///
     /// This function will fail if it is called more than once, or if another
     /// library has already initialized a global logger.
-    pub fn try_init(&mut self) -> Result<(), SetLoggerError> {
+    pub fn try_init(self) -> Result<(), SetLoggerError> {
         let logger = self.build();
 
         let max_level = logger.filter();
@@ -753,7 +753,7 @@ impl Builder {
     ///
     /// This function will panic if it is called more than once, or if another
     /// library has already initialized a global logger.
-    pub fn init(&mut self) {
+    pub fn init(self) {
         self.try_init()
             .expect("Builder::init should not be called after logger initialized");
     }
@@ -762,10 +762,7 @@ impl Builder {
     ///
     /// The returned logger implements the `Log` trait and can be installed manually
     /// or nested within another logger.
-    pub fn build(&mut self) -> Logger {
-        assert!(!self.built, "attempt to re-use consumed builder");
-        self.built = true;
-
+    pub fn build(mut self) -> Logger {
         Logger {
             writer: self.writer.build(),
             filter: self.filter.build(),
@@ -1128,9 +1125,7 @@ pub fn try_init_from_env<'a, E>(env: E) -> Result<(), SetLoggerError>
 where
     E: Into<Env<'a>>,
 {
-    let mut builder = Builder::from_env(env);
-
-    builder.try_init()
+    Builder::from_env(env).try_init()
 }
 
 /// Initializes the global logger with an env logger from the given environment

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -714,6 +714,7 @@ impl Builder {
     ///
     /// If `is_test` is `true` then the logger will allow the testing framework to
     /// capture log records rather than printing them to the terminal directly.
+    #[allow(clippy::wrong_self_convention)]
     pub fn is_test(mut self, is_test: bool) -> Self {
         self.writer = self.writer.is_test(is_test);
         self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -401,9 +401,7 @@ impl Builder {
     where
         E: Into<Env<'a>>,
     {
-        let mut builder = Builder::new();
-        builder.parse_env(env);
-        builder
+        Builder::new().parse_env(env)
     }
 
     /// Applies the configuration from the environment.
@@ -420,11 +418,10 @@ impl Builder {
     /// use log::LevelFilter;
     /// use env_logger::Builder;
     ///
-    /// let mut builder = Builder::new();
-    ///
-    /// builder.filter_level(LevelFilter::Off);
-    /// builder.parse_env("MY_LOG");
-    /// builder.init();
+    /// Builder::new()
+    ///     .filter_level(LevelFilter::Off)
+    ///     .parse_env("MY_LOG")
+    ///     .init();
     /// ```
     ///
     /// Initialise a logger with filter level `Off`, then use the `MY_LOG`
@@ -437,23 +434,23 @@ impl Builder {
     ///
     /// let env = Env::new().filter("MY_LOG").write_style("MY_LOG_STYLE");
     ///
-    /// let mut builder = Builder::new();
-    /// builder.filter_level(LevelFilter::Off);
-    /// builder.parse_env(env);
-    /// builder.init();
+    /// Builder::new()
+    ///     .filter_level(LevelFilter::Off)
+    ///     .parse_env(env)
+    ///     .init();
     /// ```
-    pub fn parse_env<'a, E>(&mut self, env: E) -> &mut Self
+    pub fn parse_env<'a, E>(mut self, env: E) -> Self
     where
         E: Into<Env<'a>>,
     {
         let env = env.into();
 
         if let Some(s) = env.get_filter() {
-            self.parse_filters(&s);
+            self = self.parse_filters(&s);
         }
 
         if let Some(s) = env.get_write_style() {
-            self.parse_write_style(&s);
+            self = self.parse_write_style(&s);
         }
 
         self
@@ -496,14 +493,14 @@ impl Builder {
     /// use log::LevelFilter;
     /// use env_logger::Builder;
     ///
-    /// let mut builder = Builder::new();
-    /// builder.filter_level(LevelFilter::Off);
-    /// builder.parse_default_env();
-    /// builder.init();
+    /// let mut builder = Builder::new()
+    ///     .filter_level(LevelFilter::Off)
+    ///     .parse_default_env()
+    ///     .init();
     /// ```
     ///
     /// [default environment variables]: struct.Env.html#default-environment-variables
-    pub fn parse_default_env(&mut self) -> &mut Self {
+    pub fn parse_default_env(self) -> Self {
         self.parse_env(Env::default())
     }
 
@@ -533,7 +530,7 @@ impl Builder {
     /// [`Formatter`]: fmt/struct.Formatter.html
     /// [`String`]: https://doc.rust-lang.org/stable/std/string/struct.String.html
     /// [`std::fmt`]: https://doc.rust-lang.org/std/fmt/index.html
-    pub fn format<F: 'static>(&mut self, format: F) -> &mut Self
+    pub fn format<F: 'static>(mut self, format: F) -> Self
     where
         F: Fn(&mut Formatter, &Record) -> io::Result<()> + Sync + Send,
     {
@@ -544,53 +541,53 @@ impl Builder {
     /// Use the default format.
     ///
     /// This method will clear any custom format set on the builder.
-    pub fn default_format(&mut self) -> &mut Self {
+    pub fn default_format(mut self) -> Self {
         self.format = Default::default();
         self
     }
 
     /// Whether or not to write the level in the default format.
-    pub fn format_level(&mut self, write: bool) -> &mut Self {
+    pub fn format_level(mut self, write: bool) -> Self {
         self.format.format_level = write;
         self
     }
 
     /// Whether or not to write the module path in the default format.
-    pub fn format_module_path(&mut self, write: bool) -> &mut Self {
+    pub fn format_module_path(mut self, write: bool) -> Self {
         self.format.format_module_path = write;
         self
     }
 
     /// Configures the amount of spaces to use to indent multiline log records.
     /// A value of `None` disables any kind of indentation.
-    pub fn format_indent(&mut self, indent: Option<usize>) -> &mut Self {
+    pub fn format_indent(mut self, indent: Option<usize>) -> Self {
         self.format.format_indent = indent;
         self
     }
 
     /// Configures if timestamp should be included and in what precision.
-    pub fn format_timestamp(&mut self, timestamp: Option<fmt::TimestampPrecision>) -> &mut Self {
+    pub fn format_timestamp(mut self, timestamp: Option<fmt::TimestampPrecision>) -> Self {
         self.format.format_timestamp = timestamp;
         self
     }
 
     /// Configures the timestamp to use second precision.
-    pub fn format_timestamp_secs(&mut self) -> &mut Self {
+    pub fn format_timestamp_secs(self) -> Self {
         self.format_timestamp(Some(fmt::TimestampPrecision::Seconds))
     }
 
     /// Configures the timestamp to use millisecond precision.
-    pub fn format_timestamp_millis(&mut self) -> &mut Self {
+    pub fn format_timestamp_millis(self) -> Self {
         self.format_timestamp(Some(fmt::TimestampPrecision::Millis))
     }
 
     /// Configures the timestamp to use microsecond precision.
-    pub fn format_timestamp_micros(&mut self) -> &mut Self {
+    pub fn format_timestamp_micros(self) -> Self {
         self.format_timestamp(Some(fmt::TimestampPrecision::Micros))
     }
 
     /// Configures the timestamp to use nanosecond precision.
-    pub fn format_timestamp_nanos(&mut self) -> &mut Self {
+    pub fn format_timestamp_nanos(self) -> Self {
         self.format_timestamp(Some(fmt::TimestampPrecision::Nanos))
     }
 
@@ -608,8 +605,8 @@ impl Builder {
     ///
     /// builder.filter_module("path::to::module", LevelFilter::Info);
     /// ```
-    pub fn filter_module(&mut self, module: &str, level: LevelFilter) -> &mut Self {
-        self.filter.filter_module(module, level);
+    pub fn filter_module(mut self, module: &str, level: LevelFilter) -> Self {
+        self.filter = self.filter.filter_module(module, level);
         self
     }
 
@@ -627,8 +624,8 @@ impl Builder {
     ///
     /// builder.filter_level(LevelFilter::Info);
     /// ```
-    pub fn filter_level(&mut self, level: LevelFilter) -> &mut Self {
-        self.filter.filter_level(level);
+    pub fn filter_level(mut self, level: LevelFilter) -> Self {
+        self.filter = self.filter.filter_level(level);
         self
     }
 
@@ -649,8 +646,8 @@ impl Builder {
     ///
     /// builder.filter(Some("path::to::module"), LevelFilter::Info);
     /// ```
-    pub fn filter(&mut self, module: Option<&str>, level: LevelFilter) -> &mut Self {
-        self.filter.filter(module, level);
+    pub fn filter(mut self, module: Option<&str>, level: LevelFilter) -> Self {
+        self.filter = self.filter.filter(module, level);
         self
     }
 
@@ -658,8 +655,8 @@ impl Builder {
     /// environment variable.
     ///
     /// See the module documentation for more details.
-    pub fn parse_filters(&mut self, filters: &str) -> &mut Self {
-        self.filter.parse(filters);
+    pub fn parse_filters(mut self, filters: &str) -> Self {
+        self.filter = self.filter.parse(filters);
         self
     }
 
@@ -678,8 +675,8 @@ impl Builder {
     ///
     /// builder.target(Target::Stdout);
     /// ```
-    pub fn target(&mut self, target: fmt::Target) -> &mut Self {
-        self.writer.target(target);
+    pub fn target(mut self, target: fmt::Target) -> Self {
+        self.writer = self.writer.target(target);
         self
     }
 
@@ -699,8 +696,8 @@ impl Builder {
     ///
     /// builder.write_style(WriteStyle::Never);
     /// ```
-    pub fn write_style(&mut self, write_style: fmt::WriteStyle) -> &mut Self {
-        self.writer.write_style(write_style);
+    pub fn write_style(mut self, write_style: fmt::WriteStyle) -> Self {
+        self.writer = self.writer.write_style(write_style);
         self
     }
 
@@ -708,8 +705,8 @@ impl Builder {
     /// environment variable.
     ///
     /// See the module documentation for more details.
-    pub fn parse_write_style(&mut self, write_style: &str) -> &mut Self {
-        self.writer.parse_write_style(write_style);
+    pub fn parse_write_style(mut self, write_style: &str) -> Self {
+        self.writer = self.writer.parse_write_style(write_style);
         self
     }
 
@@ -717,8 +714,8 @@ impl Builder {
     ///
     /// If `is_test` is `true` then the logger will allow the testing framework to
     /// capture log records rather than printing them to the terminal directly.
-    pub fn is_test(&mut self, is_test: bool) -> &mut Self {
-        self.writer.is_test(is_test);
+    pub fn is_test(mut self, is_test: bool) -> Self {
+        self.writer = self.writer.is_test(is_test);
         self
     }
 


### PR DESCRIPTION
Previously, `build()` would take `&mut self` and panic if called more than once. This is not ideal, especially since it wasn't documented anywhere except in the source code. This now enforces that `build()` is only called once by taking `self` in build.

Unfortunately, that meant that chains like the following no longer worked:

```rust
    let stylish_logger = Builder::new()
        .filter(None, LevelFilter::Error)
        .write_style(WriteStyle::Always)
        .build();
```
```
error[E0507]: cannot move out of a mutable reference
  --> examples/direct_logger.rs:27:26
   |
27 |       let stylish_logger = Builder::new()
   |  __________________________^
28 | |         .filter(None, LevelFilter::Error)
29 | |         .write_style(WriteStyle::Always)
   | |________________________________________^ move occurs because value has type `env_logger::Builder`, which does not implement the `Copy` trait
```
It would have to instead be rewritten like this:
```rust
    let stylish_builder = Builder::new();
    builder.filter(None, LevelFilter::Error).write_style(WriteStyle::Always);
    let stylish_logger = builder.build();
```

To avoid this, I changed all the builder functions taking `&mut self -> &mut Self` to instead take `self -> Self`. That fixes the example I gave, but broke a few others:

```
error[E0382]: borrow of moved value: `builder`
  --> src/filter/mod.rs:36:21
   |
15 |         let mut builder = Builder::new();
   |             ----------- move occurs because `builder` has type `env_logger::filter::Builder`, which does not implement the `Copy` trait
...
19 |            builder.parse(filter);
   |            ------- value moved here
...
23 |             filter: builder.build()
   |                     ^^^^^^^ value borrowed here after move
```

Those I just rewrote to use `Builder::new().parse(filter).build()` instead, since that seems more idiomatic.

This is a breaking change.

## Alternatives

- Take `self` in `build()` and related constructors, and ask users to use `builder.x(); builder.build()` instead
- Don't change the API at all