### PR TITLE
Don't use eprint from logger implementations.

### DIFF
--- a/src/fmt/writer/termcolor/extern_impl.rs
+++ b/src/fmt/writer/termcolor/extern_impl.rs
@@ -102,17 +102,14 @@ impl BufferWriter {
 
     pub(in crate::fmt::writer) fn print(&self, buf: &Buffer) -> io::Result<()> {
         if let Some(target) = self.test_target {
-            // This impl uses the `eprint` and `print` macros
-            // instead of `termcolor`'s buffer.
-            // This is so their output can be captured by `cargo test`
-            let log = String::from_utf8_lossy(buf.bytes());
-
+            // This impl writes directly to stderr / stdout instead of using
+            // `termcolor`'s buffer.  This is so their output can be captured by
+            // `cargo test`
             match target {
-                Target::Stderr => eprint!("{}", log),
-                Target::Stdout => print!("{}", log),
+                Target::Stderr => io::stderr().write_all(buf.bytes()),
+                Target::Stdout => io::stdout().write_all(buf.bytes()),
             }
-
-            Ok(())
+            .map(|_| ())
         } else {
             self.inner.print(&buf.inner)
         }

--- a/src/fmt/writer/termcolor/shim_impl.rs
+++ b/src/fmt/writer/termcolor/shim_impl.rs
@@ -28,17 +28,15 @@ impl BufferWriter {
     }
 
     pub(in crate::fmt::writer) fn print(&self, buf: &Buffer) -> io::Result<()> {
-        // This impl uses the `eprint` and `print` macros
-        // instead of using the streams directly.
-        // This is so their output can be captured by `cargo test`
-        let log = String::from_utf8_lossy(&buf.0);
+        use std::io::Write;
 
+        // This impl writes to stdout / stderr instead of using the streams
+        // directly.  This is so their output can be captured by `cargo test`
         match self.target {
-            Target::Stderr => eprint!("{}", log),
-            Target::Stdout => print!("{}", log),
+            Target::Stderr => io::stderr().write_all(&buf.0),
+            Target::Stdout => io::stdout().write_all(&buf.0),
         }
-
-        Ok(())
+        .map(|_| ())
     }
 }
 


### PR DESCRIPTION
eprint! panics on io errors, which might cause unnecessary crashes like
https://bugzilla.mozilla.org/show_bug.cgi?id=1676882.