### PR TITLE
Add suffix customization to default formatter.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -632,6 +632,12 @@ impl Builder {
         self.format_timestamp(Some(fmt::TimestampPrecision::Nanos))
     }
 
+    /// Configures the end of line suffix.
+    pub fn format_suffix(&mut self, suffix: &'static str) -> &mut Self {
+        self.format.format_suffix = suffix;
+        self
+    }
+
     /// Adds a directive to the filter for a specific module.
     ///
     /// # Examples


### PR DESCRIPTION
This defaults to the same suffix as before, \n.
Supports several use cases:
* When writing to a raw TTY, \r\n is required
* Custom formatting of messages may be desirable, e.g. \n\n