### PR TITLE
Add Target::Pipe

### DIFF
--- a/examples/custom_target.rs
+++ b/examples/custom_target.rs
@@ -18,7 +18,7 @@ $ export MY_LOG_STYLE=never
 #[macro_use]
 extern crate log;
 
-use env_logger::{Builder, Env};
+use env_logger::{Builder, Env, Target};
 use std::{
     io,
     sync::mpsc::{channel, Sender},
@@ -58,7 +58,7 @@ fn main() {
     Builder::from_env(env)
         // The Sender of the channel is given to the logger
         // The wrapper is used, because Sender itself doesn't implement io::Write
-        .target_pipe(WriteAdapter { sender: rx })
+        .target(Target::Pipe(Box::new(WriteAdapter { sender: rx })))
         .init();
 
     trace!("some trace log");

--- a/examples/custom_target.rs
+++ b/examples/custom_target.rs
@@ -1,0 +1,81 @@
+/*!
+Using `env_logger`.
+
+Before running this example, try setting the `MY_LOG_LEVEL` environment variable to `info`:
+
+```no_run,shell
+$ export MY_LOG_LEVEL='info'
+```
+
+Also try setting the `MY_LOG_STYLE` environment variable to `never` to disable colors
+or `auto` to enable them:
+
+```no_run,shell
+$ export MY_LOG_STYLE=never
+```
+*/
+
+#[macro_use]
+extern crate log;
+
+use env_logger::{Builder, Env};
+use std::{
+    io,
+    sync::mpsc::{channel, Sender},
+};
+
+// This struct is used as an adaptor, it implements io::Write and forwards the buffer to a mpsc::Sender
+struct WriteAdapter {
+    sender: Sender<u8>,
+}
+
+impl io::Write for WriteAdapter {
+    // On write we forward each u8 of the buffer to the sender and return the length of the buffer
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        for chr in buf {
+            self.sender.send(*chr).unwrap();
+        }
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+fn main() {
+    // The `Env` lets us tweak what the environment
+    // variables to read are and what the default
+    // value is if they're missing
+    let env = Env::default()
+        .filter_or("MY_LOG_LEVEL", "trace")
+        // Normaly using a pipe as target would asume this as false, but this forces it to true
+        .write_style_or("MY_LOG_STYLE", "always");
+
+    // Create the channel for the log messages
+    let (rx, tx) = channel();
+
+    Builder::from_env(env)
+        // The Sender of the channel is given to the logger
+        // The wrapper is used, because Sender itself doesn't implement io::Write
+        .target_pipe(WriteAdapter { sender: rx })
+        .init();
+
+    trace!("some trace log");
+    debug!("some debug log");
+    info!("some information log");
+    warn!("some warning log");
+    error!("some error log");
+
+    // Collect all messages send to the channel and parse the result as a string
+    String::from_utf8(tx.try_iter().collect::<Vec<u8>>())
+        .unwrap()
+        // Split the result into lines so a prefix can be added to each line
+        .split("\n")
+        .for_each(|msg| {
+            // Print the message with a prefix if it has any content
+            if msg.len() > 0 {
+                println!("from pipe: {}", msg)
+            }
+        });
+}

--- a/examples/custom_target.rs
+++ b/examples/custom_target.rs
@@ -49,7 +49,7 @@ fn main() {
     // value is if they're missing
     let env = Env::default()
         .filter_or("MY_LOG_LEVEL", "trace")
-        // Normaly using a pipe as target would asume this as false, but this forces it to true
+        // Normally using a pipe as a target would mean a value of false, but this forces it to be true.
         .write_style_or("MY_LOG_STYLE", "always");
 
     // Create the channel for the log messages

--- a/examples/custom_target.rs
+++ b/examples/custom_target.rs
@@ -57,7 +57,7 @@ fn main() {
 
     Builder::from_env(env)
         // The Sender of the channel is given to the logger
-        // The wrapper is used, because Sender itself doesn't implement io::Write
+        // A wrapper is needed, because the `Sender` itself doesn't implement `std::io::Write`.
         .target(Target::Pipe(Box::new(WriteAdapter { sender: rx })))
         .init();
 

--- a/src/fmt/writer/mod.rs
+++ b/src/fmt/writer/mod.rs
@@ -15,10 +15,41 @@ pub(in crate::fmt) mod glob {
 
 pub(in crate::fmt) use self::termcolor::Buffer;
 
-/// Log target, either `stdout` or `stderr`.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+/// Log target, either `stdout`, `stderr` or a custom pipe.
 #[non_exhaustive]
 pub enum Target {
+    /// Logs will be sent to standard output.
+    Stdout,
+    /// Logs will be sent to standard error.
+    Stderr,
+    /// Logs will be sent to a custom pipe.
+    Pipe(Box<dyn io::Write + Send + 'static>),
+}
+
+impl Default for Target {
+    fn default() -> Self {
+        Target::Stderr
+    }
+}
+
+impl fmt::Debug for Target {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Stdout => "stdout",
+                Self::Stderr => "stderr",
+                Self::Pipe(_) => "pipe",
+            }
+        )
+    }
+}
+
+/// Log target, either `stdout`, `stderr` or a custom pipe.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[non_exhaustive]
+pub(in crate::fmt) enum TargetType {
     /// Logs will be sent to standard output.
     Stdout,
     /// Logs will be sent to standard error.
@@ -27,9 +58,19 @@ pub enum Target {
     Pipe,
 }
 
-impl Default for Target {
+impl From<&Target> for TargetType {
+    fn from(target: &Target) -> Self {
+        match target {
+            Target::Stdout => Self::Stdout,
+            Target::Stderr => Self::Stderr,
+            Target::Pipe(_) => Self::Pipe,
+        }
+    }
+}
+
+impl Default for TargetType {
     fn default() -> Self {
-        Target::Stderr
+        Self::from(&Target::default())
     }
 }
 
@@ -74,7 +115,7 @@ impl Writer {
 ///
 /// The target and style choice can be configured before building.
 pub(crate) struct Builder {
-    target: Target,
+    target_type: TargetType,
     target_pipe: Option<Arc<Mutex<dyn io::Write + Send + 'static>>>,
     write_style: WriteStyle,
     is_test: bool,
@@ -85,7 +126,7 @@ impl Builder {
     /// Initialize the writer builder with defaults.
     pub(crate) fn new() -> Self {
         Builder {
-            target: Default::default(),
+            target_type: Default::default(),
             target_pipe: None,
             write_style: Default::default(),
             is_test: false,
@@ -95,24 +136,11 @@ impl Builder {
 
     /// Set the target to write to.
     pub(crate) fn target(&mut self, target: Target) -> &mut Self {
-        if let Target::Pipe = target {
-            panic!("Can not set target to Target::Pipe, use the target_pipe method for that");
-        }
-        self.target = target;
-        self.target_pipe = None;
-        self
-    }
-
-    /// Set the target to write to a custom pipe.
-    ///
-    /// This can be used to send the log to a file directly or something more complex.
-    /// It is advertised to use a handle for log files, so that rollover and slow FSs are handled well.
-    pub(crate) fn target_pipe<W: io::Write + Send + 'static>(
-        &mut self,
-        target_pipe: W,
-    ) -> &mut Self {
-        self.target_pipe = Some(Arc::new(Mutex::new(target_pipe)));
-        self.target = Target::Pipe;
+        self.target_type = TargetType::from(&target);
+        self.target_pipe = match target {
+            Target::Stdout | Target::Stderr => None,
+            Target::Pipe(pipe) => Some(Arc::new(Mutex::new(pipe))),
+        };
         self
     }
 
@@ -144,10 +172,10 @@ impl Builder {
 
         let color_choice = match self.write_style {
             WriteStyle::Auto => {
-                if match self.target {
-                    Target::Stderr => is_stderr(),
-                    Target::Stdout => is_stdout(),
-                    Target::Pipe => false,
+                if match self.target_type {
+                    TargetType::Stderr => is_stderr(),
+                    TargetType::Stdout => is_stdout(),
+                    TargetType::Pipe => false,
                 } {
                     WriteStyle::Auto
                 } else {
@@ -157,10 +185,10 @@ impl Builder {
             color_choice => color_choice,
         };
 
-        let writer = match self.target {
-            Target::Stderr => BufferWriter::stderr(self.is_test, color_choice),
-            Target::Stdout => BufferWriter::stdout(self.is_test, color_choice),
-            Target::Pipe => {
+        let writer = match self.target_type {
+            TargetType::Stderr => BufferWriter::stderr(self.is_test, color_choice),
+            TargetType::Stdout => BufferWriter::stdout(self.is_test, color_choice),
+            TargetType::Pipe => {
                 BufferWriter::pipe(color_choice, self.target_pipe.as_ref().unwrap().clone())
             }
         };
@@ -181,7 +209,7 @@ impl Default for Builder {
 impl fmt::Debug for Builder {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("Logger")
-            .field("target", &self.target)
+            .field("target", &self.target_type)
             .field("write_style", &self.write_style)
             .finish()
     }

--- a/src/fmt/writer/mod.rs
+++ b/src/fmt/writer/mod.rs
@@ -23,7 +23,7 @@ pub enum Target {
     Stdout,
     /// Logs will be sent to standard error.
     Stderr,
-    /// Logs will be send to a custom pipe.
+    /// Logs will be sent to a custom pipe.
     Pipe,
 }
 

--- a/src/fmt/writer/termcolor/shim_impl.rs
+++ b/src/fmt/writer/termcolor/shim_impl.rs
@@ -59,6 +59,7 @@ impl BufferWriter {
             TargetType::Stdout => print!("{}", String::from_utf8_lossy(&buf.0)),
             TargetType::Stderr => eprint!("{}", String::from_utf8_lossy(&buf.0)),
         }
+
         Ok(())
     }
 }

--- a/src/fmt/writer/termcolor/shim_impl.rs
+++ b/src/fmt/writer/termcolor/shim_impl.rs
@@ -3,12 +3,12 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use crate::fmt::{Target, WriteStyle};
+use crate::fmt::{TargetType, WriteStyle};
 
 pub(in crate::fmt::writer) mod glob {}
 
 pub(in crate::fmt::writer) struct BufferWriter {
-    target: Target,
+    target: TargetType,
     target_pipe: Option<Arc<Mutex<dyn io::Write + Send + 'static>>>,
 }
 
@@ -17,14 +17,14 @@ pub(in crate::fmt) struct Buffer(Vec<u8>);
 impl BufferWriter {
     pub(in crate::fmt::writer) fn stderr(_is_test: bool, _write_style: WriteStyle) -> Self {
         BufferWriter {
-            target: Target::Stderr,
+            target: TargetType::Stderr,
             target_pipe: None,
         }
     }
 
     pub(in crate::fmt::writer) fn stdout(_is_test: bool, _write_style: WriteStyle) -> Self {
         BufferWriter {
-            target: Target::Stdout,
+            target: TargetType::Stdout,
             target_pipe: None,
         }
     }
@@ -34,7 +34,7 @@ impl BufferWriter {
         target_pipe: Arc<Mutex<dyn io::Write + Send + 'static>>,
     ) -> Self {
         BufferWriter {
-            target: Target::Pipe,
+            target: TargetType::Pipe,
             target_pipe: Some(target_pipe),
         }
     }
@@ -44,7 +44,7 @@ impl BufferWriter {
     }
 
     pub(in crate::fmt::writer) fn print(&self, buf: &Buffer) -> io::Result<()> {
-        if let Target::Pipe = self.target {
+        if let TargetType::Pipe = self.target {
             self.target_pipe
                 .as_ref()
                 .unwrap()
@@ -58,9 +58,9 @@ impl BufferWriter {
             let log = String::from_utf8_lossy(&buf.0);
 
             match self.target {
-                Target::Stderr => eprint!("{}", log),
-                Target::Stdout => print!("{}", log),
-                Target::Pipe => unreachable!(),
+                TargetType::Stderr => eprint!("{}", log),
+                TargetType::Stdout => print!("{}", log),
+                TargetType::Pipe => unreachable!(),
             }
 
             Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -709,6 +709,7 @@ impl Builder {
     /// Sets the target for the log output.
     ///
     /// Env logger can log to either stdout or stderr. The default is stderr.
+    /// If you want to set the target to a custom pipe, use [`target_pipe`], this will panic if given [`Target::Pipe`].
     ///
     /// # Examples
     ///
@@ -721,8 +722,37 @@ impl Builder {
     ///
     /// builder.target(Target::Stdout);
     /// ```
+    ///
+    /// [`target_pipe`]: #method.target_pipe
+    /// [`Target::Pipe`]: enum.Target.html#variant.Pipe
     pub fn target(&mut self, target: fmt::Target) -> &mut Self {
         self.writer.target(target);
+        self
+    }
+
+    /// Sets the target for the log output to a custom pipe.
+    ///
+    /// Replaces the target set by [`target`] if executed and the other way around.
+    ///
+    /// This can be used to send the log to a file directly or something more complex.
+    /// It is advertised to use a wrapper for log files, so that rollover and slow FSs are handled well.
+    ///
+    /// # Examples
+    ///
+    /// Write log message to file `example.log`:
+    ///
+    /// ```
+    /// use env_logger::{Builder};
+    /// use std::fs::File;
+    ///
+    /// let mut builder = Builder::new();
+    ///
+    /// builder.target_pipe(File::open("example.log").unwrap());
+    /// ```
+    ///
+    /// [`target`]: #method.target
+    pub fn target_pipe<W: io::Write + Send + 'static>(&mut self, target_pipe: W) -> &mut Self {
+        self.writer.target_pipe(target_pipe);
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -708,8 +708,10 @@ impl Builder {
 
     /// Sets the target for the log output.
     ///
-    /// Env logger can log to either stdout or stderr. The default is stderr.
-    /// If you want to set the target to a custom pipe, use [`target_pipe`], this will panic if given [`Target::Pipe`].
+    /// Env logger can log to either stdout, stderr or a custom pipe. The default is stderr.
+    ///
+    /// The custom pipe can be used to send the log to a file directly or something more complex.
+    /// It is advertised to use a wrapper for log files, so that rollover and slow FSs are handled well.
     ///
     /// # Examples
     ///
@@ -722,39 +724,8 @@ impl Builder {
     ///
     /// builder.target(Target::Stdout);
     /// ```
-    ///
-    /// [`target_pipe`]: #method.target_pipe
-    /// [`Target::Pipe`]: enum.Target.html#variant.Pipe
     pub fn target(&mut self, target: fmt::Target) -> &mut Self {
         self.writer.target(target);
-        self
-    }
-
-    /// Sets the target for the log output to a custom pipe.
-    ///
-    /// Replaces the target set by [`target`] if executed and the other way around.
-    ///
-    /// This can be used to send the log to a file directly or something more complex.
-    /// It is advertised to use a wrapper for log files, so that rollover and slow FSs are handled well.
-    ///
-    /// # Examples
-    ///
-    /// Write log message to file `example.log`:
-    ///
-    /// ```
-    /// use env_logger::{Builder};
-    /// use std::fs::File;
-    ///
-    /// let mut builder = Builder::new();
-    ///
-    /// builder.target_pipe(
-    ///     File::open("example.log").unwrap_or_else(|_| File::create("example.log").unwrap()),
-    /// );
-    /// ```
-    ///
-    /// [`target`]: #method.target
-    pub fn target_pipe<W: io::Write + Send + 'static>(&mut self, target_pipe: W) -> &mut Self {
-        self.writer.target_pipe(target_pipe);
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -747,7 +747,9 @@ impl Builder {
     ///
     /// let mut builder = Builder::new();
     ///
-    /// builder.target_pipe(File::open("example.log").unwrap());
+    /// builder.target_pipe(
+    ///     File::open("example.log").unwrap_or_else(|_| File::create("example.log").unwrap()),
+    /// );
     /// ```
     ///
     /// [`target`]: #method.target

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -710,8 +710,8 @@ impl Builder {
     ///
     /// Env logger can log to either stdout, stderr or a custom pipe. The default is stderr.
     ///
-    /// The custom pipe can be used to send the log to a file directly or something more complex.
-    /// It is advertised to use a wrapper for log files, so that rollover and slow FSs are handled well.
+    /// The custom pipe can be used to send the log messages to a custom sink (for example a file).
+    /// Do note that direct writes to a file can become a bottleneck due to IO operation times.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Now logs can be written to custom pipes and not just to stdout or stderr.

This is my take on #178.

I would be very happy to hear some feedback, since I'm quite unsure about a few changes:
- The [example](examples/custom_target.rs) seams overly complicated, mostly because I didn't want an example to write to a file. Maybe there is a better candidate than `std::sync::mpsc` used as a pipe for that?
- [`Builder::target_pipe`](src/fmt/writer/mod.rs#R110) is my idea for not breaking too much, but maybe there is a solution to implement that into [`Builder::target`](src/fmt/writer/mod.rs#R97) directly?
- In [`Buffer`](src/fmt/writer/termcolor/extern_impl.rs#R100) it is assumed that if `target_pipe` is `Some`, `test_target` is always `None`. Is there a better way to enforce that?