### PR TITLE
Override existing directives when parsing

### DIFF
--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -220,6 +220,10 @@ impl Builder {
 
         self.filter = filter;
 
+        // Overwrite existing directives with the same name.
+        self.directives
+            .retain(|d| directives.iter().all(|n| n.name != d.name));
+
         for directive in directives {
             self.directives.push(directive);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1277,4 +1277,20 @@ mod tests {
 
         assert_eq!(Some("from default".to_owned()), env.get_write_style());
     }
+
+    #[test]
+    fn builder_parse_env_overrides_existing_filters() {
+        env::set_var(
+            "builder_parse_default_env_overrides_existing_filters",
+            "debug",
+        );
+        let env = Env::new().filter("builder_parse_default_env_overrides_existing_filters");
+
+        let mut builder = Builder::new();
+        builder.filter_level(LevelFilter::Trace);
+        // Overrides global level to debug
+        builder.parse_env(env);
+
+        assert_eq!(builder.filter.build().filter(), LevelFilter::Debug);
+    }
 }


### PR DESCRIPTION
This should work as a minimal fix for #196.

Let me know if you would like `filter::Builder::filter()` to behave in the same way (i.e., removing existing directives with the same name). Also, please let me know if this fix doesn't make sense -- I'm not familiar with this code, and even just starting out with Rust as well.