### PR TITLE
Ensure unique directive names when building filters

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1277,4 +1277,20 @@ mod tests {
 
         assert_eq!(Some("from default".to_owned()), env.get_write_style());
     }
+
+    #[test]
+    fn builder_parse_env_overrides_existing_filters() {
+        env::set_var(
+            "builder_parse_default_env_overrides_existing_filters",
+            "debug",
+        );
+        let env = Env::new().filter("builder_parse_default_env_overrides_existing_filters");
+
+        let mut builder = Builder::new();
+        builder.filter_level(LevelFilter::Trace);
+        // Overrides global level to debug
+        builder.parse_env(env);
+
+        assert_eq!(builder.filter.build().filter(), LevelFilter::Debug);
+    }
 }


### PR DESCRIPTION
This is an alternative fix for #196, if we are OK with all later calls to the various `filter::Builder` methods taking precedence over earlier calls.