### PR TITLE
Add Target::Pipe cleaned up

### DIFF
--- a/ci/src/main.rs
+++ b/ci/src/main.rs
@@ -29,7 +29,7 @@ fn main() {
         })
         .collect::<Vec<_>>();
 
-    if failed.len() > 0 {
+    if !failed.is_empty() {
         for failed in failed {
             eprintln!("FAIL: {:?}", failed);
         }

--- a/ci/src/permute.rs
+++ b/ci/src/permute.rs
@@ -6,7 +6,7 @@ where
 {
     let mut permutations = BTreeSet::new();
 
-    if input.len() == 0 {
+    if input.is_empty() {
         return permutations;
     }
 

--- a/ci/src/task.rs
+++ b/ci/src/task.rs
@@ -21,12 +21,12 @@ impl Default for TestArgs {
 
 impl TestArgs {
     fn features_string(&self) -> Option<String> {
-        if self.features.len() == 0 {
+        if self.features.is_empty() {
             return None;
         }
 
         let s = self.features.iter().fold(String::new(), |mut s, f| {
-            if s.len() > 0 {
+            if !s.is_empty() {
                 s.push_str(" ");
             }
             s.push_str(f);

--- a/examples/custom_target.rs
+++ b/examples/custom_target.rs
@@ -18,7 +18,7 @@ $ export MY_LOG_STYLE=never
 #[macro_use]
 extern crate log;
 
-use env_logger::{Builder, Env};
+use env_logger::{Builder, Env, Target};
 use std::{
     io,
     sync::mpsc::{channel, Sender},
@@ -58,7 +58,7 @@ fn main() {
     Builder::from_env(env)
         // The Sender of the channel is given to the logger
         // The wrapper is used, because Sender itself doesn't implement io::Write
-        .target_pipe(WriteAdapter { sender: rx })
+        .target(Target::Pipe(Box::new(WriteAdapter { sender: rx })))
         .init();
 
     trace!("some trace log");

--- a/examples/custom_target.rs
+++ b/examples/custom_target.rs
@@ -1,0 +1,81 @@
+/*!
+Using `env_logger`.
+
+Before running this example, try setting the `MY_LOG_LEVEL` environment variable to `info`:
+
+```no_run,shell
+$ export MY_LOG_LEVEL='info'
+```
+
+Also try setting the `MY_LOG_STYLE` environment variable to `never` to disable colors
+or `auto` to enable them:
+
+```no_run,shell
+$ export MY_LOG_STYLE=never
+```
+*/
+
+#[macro_use]
+extern crate log;
+
+use env_logger::{Builder, Env};
+use std::{
+    io,
+    sync::mpsc::{channel, Sender},
+};
+
+// This struct is used as an adaptor, it implements io::Write and forwards the buffer to a mpsc::Sender
+struct WriteAdapter {
+    sender: Sender<u8>,
+}
+
+impl io::Write for WriteAdapter {
+    // On write we forward each u8 of the buffer to the sender and return the length of the buffer
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        for chr in buf {
+            self.sender.send(*chr).unwrap();
+        }
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+fn main() {
+    // The `Env` lets us tweak what the environment
+    // variables to read are and what the default
+    // value is if they're missing
+    let env = Env::default()
+        .filter_or("MY_LOG_LEVEL", "trace")
+        // Normaly using a pipe as target would asume this as false, but this forces it to true
+        .write_style_or("MY_LOG_STYLE", "always");
+
+    // Create the channel for the log messages
+    let (rx, tx) = channel();
+
+    Builder::from_env(env)
+        // The Sender of the channel is given to the logger
+        // The wrapper is used, because Sender itself doesn't implement io::Write
+        .target_pipe(WriteAdapter { sender: rx })
+        .init();
+
+    trace!("some trace log");
+    debug!("some debug log");
+    info!("some information log");
+    warn!("some warning log");
+    error!("some error log");
+
+    // Collect all messages send to the channel and parse the result as a string
+    String::from_utf8(tx.try_iter().collect::<Vec<u8>>())
+        .unwrap()
+        // Split the result into lines so a prefix can be added to each line
+        .split("\n")
+        .for_each(|msg| {
+            // Print the message with a prefix if it has any content
+            if msg.len() > 0 {
+                println!("from pipe: {}", msg)
+            }
+        });
+}

--- a/examples/custom_target.rs
+++ b/examples/custom_target.rs
@@ -49,7 +49,7 @@ fn main() {
     // value is if they're missing
     let env = Env::default()
         .filter_or("MY_LOG_LEVEL", "trace")
-        // Normaly using a pipe as target would asume this as false, but this forces it to true
+        // Normally using a pipe as a target would mean a value of false, but this forces it to be true.
         .write_style_or("MY_LOG_STYLE", "always");
 
     // Create the channel for the log messages

--- a/examples/custom_target.rs
+++ b/examples/custom_target.rs
@@ -71,10 +71,10 @@ fn main() {
     String::from_utf8(tx.try_iter().collect::<Vec<u8>>())
         .unwrap()
         // Split the result into lines so a prefix can be added to each line
-        .split("\n")
+        .split('\n')
         .for_each(|msg| {
             // Print the message with a prefix if it has any content
-            if msg.len() > 0 {
+            if !msg.is_empty() {
                 println!("from pipe: {}", msg)
             }
         });

--- a/examples/custom_target.rs
+++ b/examples/custom_target.rs
@@ -57,7 +57,7 @@ fn main() {
 
     Builder::from_env(env)
         // The Sender of the channel is given to the logger
-        // The wrapper is used, because Sender itself doesn't implement io::Write
+        // A wrapper is needed, because the `Sender` itself doesn't implement `std::io::Write`.
         .target(Target::Pipe(Box::new(WriteAdapter { sender: rx })))
         .init();
 

--- a/src/fmt/writer/mod.rs
+++ b/src/fmt/writer/mod.rs
@@ -71,6 +71,19 @@ impl Default for WritableTarget {
     }
 }
 
+impl fmt::Debug for WritableTarget {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Stdout => "stdout",
+                Self::Stderr => "stderr",
+                Self::Pipe(_) => "pipe",
+            }
+        )
+    }
+}
 /// Whether or not to print styles to the target.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum WriteStyle {
@@ -111,6 +124,7 @@ impl Writer {
 /// A builder for a terminal writer.
 ///
 /// The target and style choice can be configured before building.
+#[derive(Debug)]
 pub(crate) struct Builder {
     target: WritableTarget,
     write_style: WriteStyle,
@@ -192,14 +206,6 @@ impl Builder {
 impl Default for Builder {
     fn default() -> Self {
         Builder::new()
-    }
-}
-
-impl fmt::Debug for Builder {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("Logger")
-            .field("write_style", &self.write_style)
-            .finish()
     }
 }
 

--- a/src/fmt/writer/mod.rs
+++ b/src/fmt/writer/mod.rs
@@ -15,10 +15,41 @@ pub(in crate::fmt) mod glob {
 
 pub(in crate::fmt) use self::termcolor::Buffer;
 
-/// Log target, either `stdout` or `stderr`.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+/// Log target, either `stdout`, `stderr` or a custom pipe.
 #[non_exhaustive]
 pub enum Target {
+    /// Logs will be sent to standard output.
+    Stdout,
+    /// Logs will be sent to standard error.
+    Stderr,
+    /// Logs will be sent to a custom pipe.
+    Pipe(Box<dyn io::Write + Send + 'static>),
+}
+
+impl Default for Target {
+    fn default() -> Self {
+        Target::Stderr
+    }
+}
+
+impl fmt::Debug for Target {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Stdout => "stdout",
+                Self::Stderr => "stderr",
+                Self::Pipe(_) => "pipe",
+            }
+        )
+    }
+}
+
+/// Log target, either `stdout`, `stderr` or a custom pipe.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[non_exhaustive]
+pub(in crate::fmt) enum TargetType {
     /// Logs will be sent to standard output.
     Stdout,
     /// Logs will be sent to standard error.
@@ -27,9 +58,19 @@ pub enum Target {
     Pipe,
 }
 
-impl Default for Target {
+impl From<&Target> for TargetType {
+    fn from(target: &Target) -> Self {
+        match target {
+            Target::Stdout => Self::Stdout,
+            Target::Stderr => Self::Stderr,
+            Target::Pipe(_) => Self::Pipe,
+        }
+    }
+}
+
+impl Default for TargetType {
     fn default() -> Self {
-        Target::Stderr
+        Self::from(&Target::default())
     }
 }
 
@@ -74,7 +115,7 @@ impl Writer {
 ///
 /// The target and style choice can be configured before building.
 pub(crate) struct Builder {
-    target: Target,
+    target_type: TargetType,
     target_pipe: Option<Arc<Mutex<dyn io::Write + Send + 'static>>>,
     write_style: WriteStyle,
     is_test: bool,
@@ -85,7 +126,7 @@ impl Builder {
     /// Initialize the writer builder with defaults.
     pub(crate) fn new() -> Self {
         Builder {
-            target: Default::default(),
+            target_type: Default::default(),
             target_pipe: None,
             write_style: Default::default(),
             is_test: false,
@@ -95,24 +136,11 @@ impl Builder {
 
     /// Set the target to write to.
     pub(crate) fn target(&mut self, target: Target) -> &mut Self {
-        if let Target::Pipe = target {
-            panic!("Can not set target to Target::Pipe, use the target_pipe method for that");
-        }
-        self.target = target;
-        self.target_pipe = None;
-        self
-    }
-
-    /// Set the target to write to a custom pipe.
-    ///
-    /// This can be used to send the log to a file directly or something more complex.
-    /// It is advertised to use a handle for log files, so that rollover and slow FSs are handled well.
-    pub(crate) fn target_pipe<W: io::Write + Send + 'static>(
-        &mut self,
-        target_pipe: W,
-    ) -> &mut Self {
-        self.target_pipe = Some(Arc::new(Mutex::new(target_pipe)));
-        self.target = Target::Pipe;
+        self.target_type = TargetType::from(&target);
+        self.target_pipe = match target {
+            Target::Stdout | Target::Stderr => None,
+            Target::Pipe(pipe) => Some(Arc::new(Mutex::new(pipe))),
+        };
         self
     }
 
@@ -144,10 +172,10 @@ impl Builder {
 
         let color_choice = match self.write_style {
             WriteStyle::Auto => {
-                if match self.target {
-                    Target::Stderr => is_stderr(),
-                    Target::Stdout => is_stdout(),
-                    Target::Pipe => false,
+                if match self.target_type {
+                    TargetType::Stderr => is_stderr(),
+                    TargetType::Stdout => is_stdout(),
+                    TargetType::Pipe => false,
                 } {
                     WriteStyle::Auto
                 } else {
@@ -157,10 +185,10 @@ impl Builder {
             color_choice => color_choice,
         };
 
-        let writer = match self.target {
-            Target::Stderr => BufferWriter::stderr(self.is_test, color_choice),
-            Target::Stdout => BufferWriter::stdout(self.is_test, color_choice),
-            Target::Pipe => {
+        let writer = match self.target_type {
+            TargetType::Stderr => BufferWriter::stderr(self.is_test, color_choice),
+            TargetType::Stdout => BufferWriter::stdout(self.is_test, color_choice),
+            TargetType::Pipe => {
                 BufferWriter::pipe(color_choice, self.target_pipe.as_ref().unwrap().clone())
             }
         };
@@ -181,7 +209,7 @@ impl Default for Builder {
 impl fmt::Debug for Builder {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("Logger")
-            .field("target", &self.target)
+            .field("target", &self.target_type)
             .field("write_style", &self.write_style)
             .finish()
     }

--- a/src/fmt/writer/mod.rs
+++ b/src/fmt/writer/mod.rs
@@ -30,7 +30,7 @@ impl Default for Target {
 }
 
 impl fmt::Debug for Target {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "{}",

--- a/src/fmt/writer/mod.rs
+++ b/src/fmt/writer/mod.rs
@@ -23,7 +23,7 @@ pub enum Target {
     Stdout,
     /// Logs will be sent to standard error.
     Stderr,
-    /// Logs will be send to a custom pipe.
+    /// Logs will be sent to a custom pipe.
     Pipe,
 }
 

--- a/src/fmt/writer/mod.rs
+++ b/src/fmt/writer/mod.rs
@@ -5,12 +5,12 @@ use self::atty::{is_stderr, is_stdout};
 use self::termcolor::BufferWriter;
 use std::{fmt, io, sync::Mutex};
 
-pub(in crate::fmt) mod glob {
+pub(super) mod glob {
     pub use super::termcolor::glob::*;
     pub use super::*;
 }
 
-pub(in crate::fmt) use self::termcolor::Buffer;
+pub(super) use self::termcolor::Buffer;
 
 /// Log target, either `stdout`, `stderr` or a custom pipe.
 #[non_exhaustive]
@@ -46,7 +46,7 @@ impl fmt::Debug for Target {
 /// Log target, either `stdout`, `stderr` or a custom pipe.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 #[non_exhaustive]
-pub(in crate::fmt) enum TargetType {
+pub(super) enum TargetType {
     /// Logs will be sent to standard output.
     Stdout,
     /// Logs will be sent to standard error.
@@ -99,11 +99,11 @@ impl Writer {
         self.write_style
     }
 
-    pub(in crate::fmt) fn buffer(&self) -> Buffer {
+    pub(super) fn buffer(&self) -> Buffer {
         self.inner.buffer()
     }
 
-    pub(in crate::fmt) fn print(&self, buf: &Buffer) -> io::Result<()> {
+    pub(super) fn print(&self, buf: &Buffer) -> io::Result<()> {
         self.inner.print(buf)
     }
 }

--- a/src/fmt/writer/termcolor/extern_impl.rs
+++ b/src/fmt/writer/termcolor/extern_impl.rs
@@ -76,7 +76,7 @@ pub(in crate::fmt::writer) struct BufferWriter {
 
 pub(in crate::fmt) struct Buffer {
     inner: termcolor::Buffer,
-    test_target: bool,
+    has_test_target: bool,
 }
 
 impl BufferWriter {
@@ -121,7 +121,7 @@ impl BufferWriter {
     pub(in crate::fmt::writer) fn buffer(&self) -> Buffer {
         Buffer {
             inner: self.inner.buffer(),
-            test_target: self.test_target.is_some(),
+            has_test_target: self.test_target.is_some(),
         }
     }
 
@@ -164,7 +164,7 @@ impl Buffer {
 
     fn set_color(&mut self, spec: &ColorSpec) -> io::Result<()> {
         // Ignore styles for test captured logs because they can't be printed
-        if !self.test_target {
+        if !self.has_test_target {
             self.inner.set_color(spec)
         } else {
             Ok(())
@@ -173,7 +173,7 @@ impl Buffer {
 
     fn reset(&mut self) -> io::Result<()> {
         // Ignore styles for test captured logs because they can't be printed
-        if !self.test_target {
+        if !self.has_test_target {
             self.inner.reset()
         } else {
             Ok(())

--- a/src/fmt/writer/termcolor/extern_impl.rs
+++ b/src/fmt/writer/termcolor/extern_impl.rs
@@ -3,7 +3,7 @@ use std::cell::RefCell;
 use std::fmt;
 use std::io::{self, Write};
 use std::rc::Rc;
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 
 use log::Level;
 use termcolor::{self, ColorChoice, ColorSpec, WriteColor};
@@ -72,7 +72,7 @@ impl Formatter {
 pub(in crate::fmt::writer) struct BufferWriter {
     inner: termcolor::BufferWriter,
     test_target_type: Option<TargetType>,
-    target_pipe: Option<Arc<Mutex<dyn io::Write + Send + 'static>>>,
+    target_pipe: Option<Box<Mutex<dyn io::Write + Send + 'static>>>,
 }
 
 pub(in crate::fmt) struct Buffer {
@@ -107,7 +107,7 @@ impl BufferWriter {
 
     pub(in crate::fmt::writer) fn pipe(
         write_style: WriteStyle,
-        target_pipe: Arc<Mutex<dyn io::Write + Send + 'static>>,
+        target_pipe: Box<Mutex<dyn io::Write + Send + 'static>>,
     ) -> Self {
         BufferWriter {
             // The inner Buffer is never printed from, but it is still needed to handle coloring and other formating

--- a/src/fmt/writer/termcolor/shim_impl.rs
+++ b/src/fmt/writer/termcolor/shim_impl.rs
@@ -59,6 +59,7 @@ impl BufferWriter {
             TargetType::Stdout => print!("{}", String::from_utf8_lossy(&buf.0)),
             TargetType::Stderr => eprint!("{}", String::from_utf8_lossy(&buf.0)),
         }
+
         Ok(())
     }
 }

--- a/src/fmt/writer/termcolor/shim_impl.rs
+++ b/src/fmt/writer/termcolor/shim_impl.rs
@@ -9,7 +9,7 @@ pub(in crate::fmt::writer) mod glob {}
 
 pub(in crate::fmt::writer) struct BufferWriter {
     target: TargetType,
-    target_pipe: Option<Arc<Mutex<dyn io::Write + Send + 'static>>>,
+    target_pipe: Option<Box<Mutex<dyn io::Write + Send + 'static>>>,
 }
 
 pub(in crate::fmt) struct Buffer(Vec<u8>);
@@ -31,7 +31,7 @@ impl BufferWriter {
 
     pub(in crate::fmt::writer) fn pipe(
         _write_style: WriteStyle,
-        target_pipe: Arc<Mutex<dyn io::Write + Send + 'static>>,
+        target_pipe: Box<Mutex<dyn io::Write + Send + 'static>>,
     ) -> Self {
         BufferWriter {
             target: TargetType::Pipe,

--- a/src/fmt/writer/termcolor/shim_impl.rs
+++ b/src/fmt/writer/termcolor/shim_impl.rs
@@ -3,12 +3,12 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use crate::fmt::{Target, WriteStyle};
+use crate::fmt::{TargetType, WriteStyle};
 
 pub(in crate::fmt::writer) mod glob {}
 
 pub(in crate::fmt::writer) struct BufferWriter {
-    target: Target,
+    target: TargetType,
     target_pipe: Option<Arc<Mutex<dyn io::Write + Send + 'static>>>,
 }
 
@@ -17,14 +17,14 @@ pub(in crate::fmt) struct Buffer(Vec<u8>);
 impl BufferWriter {
     pub(in crate::fmt::writer) fn stderr(_is_test: bool, _write_style: WriteStyle) -> Self {
         BufferWriter {
-            target: Target::Stderr,
+            target: TargetType::Stderr,
             target_pipe: None,
         }
     }
 
     pub(in crate::fmt::writer) fn stdout(_is_test: bool, _write_style: WriteStyle) -> Self {
         BufferWriter {
-            target: Target::Stdout,
+            target: TargetType::Stdout,
             target_pipe: None,
         }
     }
@@ -34,7 +34,7 @@ impl BufferWriter {
         target_pipe: Arc<Mutex<dyn io::Write + Send + 'static>>,
     ) -> Self {
         BufferWriter {
-            target: Target::Pipe,
+            target: TargetType::Pipe,
             target_pipe: Some(target_pipe),
         }
     }
@@ -44,7 +44,7 @@ impl BufferWriter {
     }
 
     pub(in crate::fmt::writer) fn print(&self, buf: &Buffer) -> io::Result<()> {
-        if let Target::Pipe = self.target {
+        if let TargetType::Pipe = self.target {
             self.target_pipe
                 .as_ref()
                 .unwrap()
@@ -58,9 +58,9 @@ impl BufferWriter {
             let log = String::from_utf8_lossy(&buf.0);
 
             match self.target {
-                Target::Stderr => eprint!("{}", log),
-                Target::Stdout => print!("{}", log),
-                Target::Pipe => unreachable!(),
+                TargetType::Stderr => eprint!("{}", log),
+                TargetType::Stdout => print!("{}", log),
+                TargetType::Pipe => unreachable!(),
             }
 
             Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -709,6 +709,7 @@ impl Builder {
     /// Sets the target for the log output.
     ///
     /// Env logger can log to either stdout or stderr. The default is stderr.
+    /// If you want to set the target to a custom pipe, use [`target_pipe`], this will panic if given [`Target::Pipe`].
     ///
     /// # Examples
     ///
@@ -721,8 +722,37 @@ impl Builder {
     ///
     /// builder.target(Target::Stdout);
     /// ```
+    ///
+    /// [`target_pipe`]: #method.target_pipe
+    /// [`Target::Pipe`]: enum.Target.html#variant.Pipe
     pub fn target(&mut self, target: fmt::Target) -> &mut Self {
         self.writer.target(target);
+        self
+    }
+
+    /// Sets the target for the log output to a custom pipe.
+    ///
+    /// Replaces the target set by [`target`] if executed and the other way around.
+    ///
+    /// This can be used to send the log to a file directly or something more complex.
+    /// It is advertised to use a wrapper for log files, so that rollover and slow FSs are handled well.
+    ///
+    /// # Examples
+    ///
+    /// Write log message to file `example.log`:
+    ///
+    /// ```
+    /// use env_logger::{Builder};
+    /// use std::fs::File;
+    ///
+    /// let mut builder = Builder::new();
+    ///
+    /// builder.target_pipe(File::open("example.log").unwrap());
+    /// ```
+    ///
+    /// [`target`]: #method.target
+    pub fn target_pipe<W: io::Write + Send + 'static>(&mut self, target_pipe: W) -> &mut Self {
+        self.writer.target_pipe(target_pipe);
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -708,8 +708,10 @@ impl Builder {
 
     /// Sets the target for the log output.
     ///
-    /// Env logger can log to either stdout or stderr. The default is stderr.
-    /// If you want to set the target to a custom pipe, use [`target_pipe`], this will panic if given [`Target::Pipe`].
+    /// Env logger can log to either stdout, stderr or a custom pipe. The default is stderr.
+    ///
+    /// The custom pipe can be used to send the log to a file directly or something more complex.
+    /// It is advertised to use a wrapper for log files, so that rollover and slow FSs are handled well.
     ///
     /// # Examples
     ///
@@ -722,39 +724,8 @@ impl Builder {
     ///
     /// builder.target(Target::Stdout);
     /// ```
-    ///
-    /// [`target_pipe`]: #method.target_pipe
-    /// [`Target::Pipe`]: enum.Target.html#variant.Pipe
     pub fn target(&mut self, target: fmt::Target) -> &mut Self {
         self.writer.target(target);
-        self
-    }
-
-    /// Sets the target for the log output to a custom pipe.
-    ///
-    /// Replaces the target set by [`target`] if executed and the other way around.
-    ///
-    /// This can be used to send the log to a file directly or something more complex.
-    /// It is advertised to use a wrapper for log files, so that rollover and slow FSs are handled well.
-    ///
-    /// # Examples
-    ///
-    /// Write log message to file `example.log`:
-    ///
-    /// ```
-    /// use env_logger::{Builder};
-    /// use std::fs::File;
-    ///
-    /// let mut builder = Builder::new();
-    ///
-    /// builder.target_pipe(
-    ///     File::open("example.log").unwrap_or_else(|_| File::create("example.log").unwrap()),
-    /// );
-    /// ```
-    ///
-    /// [`target`]: #method.target
-    pub fn target_pipe<W: io::Write + Send + 'static>(&mut self, target_pipe: W) -> &mut Self {
-        self.writer.target_pipe(target_pipe);
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -747,7 +747,9 @@ impl Builder {
     ///
     /// let mut builder = Builder::new();
     ///
-    /// builder.target_pipe(File::open("example.log").unwrap());
+    /// builder.target_pipe(
+    ///     File::open("example.log").unwrap_or_else(|_| File::create("example.log").unwrap()),
+    /// );
     /// ```
     ///
     /// [`target`]: #method.target

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -710,8 +710,8 @@ impl Builder {
     ///
     /// Env logger can log to either stdout, stderr or a custom pipe. The default is stderr.
     ///
-    /// The custom pipe can be used to send the log to a file directly or something more complex.
-    /// It is advertised to use a wrapper for log files, so that rollover and slow FSs are handled well.
+    /// The custom pipe can be used to send the log messages to a custom sink (for example a file).
+    /// Do note that direct writes to a file can become a bottleneck due to IO operation times.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
#195 with some adjustments to have the pipe as enum variant data instead of a separate field.