### PR TITLE
Try to fix Target::Pipe

### DIFF
--- a/src/fmt/writer/mod.rs
+++ b/src/fmt/writer/mod.rs
@@ -193,7 +193,7 @@ impl Builder {
         let writer = match mem::take(&mut self.target) {
             WritableTarget::Stderr => BufferWriter::stderr(self.is_test, color_choice),
             WritableTarget::Stdout => BufferWriter::stdout(self.is_test, color_choice),
-            WritableTarget::Pipe(pipe) => BufferWriter::pipe(self.is_test, color_choice, pipe),
+            WritableTarget::Pipe(pipe) => BufferWriter::pipe(color_choice, pipe),
         };
 
         Writer {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -779,6 +779,8 @@ impl Builder {
     ///
     /// If `is_test` is `true` then the logger will allow the testing framework to
     /// capture log records rather than printing them to the terminal directly.
+    ///
+    /// Has no effect if the target is [`Target::Pipe`][fmt::Target::Pipe].
     pub fn is_test(&mut self, is_test: bool) -> &mut Self {
         self.writer.is_test(is_test);
         self


### PR DESCRIPTION
I thought I found a good way of dealing with this, but it didn't work out at all. I got it to almost compile but now I found that there's another set of things that all rely on there being a termcolor output buffer. (everything around `fmt::Formatter`)

@TilCreator if are you still interested in getting `Target::Pipe` fixed, maybe you can have a look at what it would take to make this work.