### PR TITLE
Fix copy-paste error in docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -676,7 +676,7 @@ impl Builder {
     ///
     /// # Examples
     ///
-    /// Only include messages for info and above for logs in `path::to::module`:
+    /// Only include messages for info and above for logs globally:
     ///
     /// ```
     /// use env_logger::Builder;


### PR DESCRIPTION
The description for the example of `Builder::filter_level` was referencing a module path even though `filter_level` is applied globally.